### PR TITLE
Add __index__ to preference classes

### DIFF
--- a/sqaodpy/sqaod/common/preference.py
+++ b/sqaodpy/sqaod/common/preference.py
@@ -60,6 +60,7 @@ class Minimize :
         return sorted(list)
     def __int__(self) :
         return 0
+    __index__ = __int__
 
     
 class Maximize :
@@ -75,6 +76,7 @@ class Maximize :
         return sorted(list, reverse = true)
     def __int__(self) :
         return 1
+    __index__ = __int__
 
 minimize = Minimize()  #: telling solvers to minimize QUBO energy.
 maximize = Maximize()  #: telling solvers to maximize QUBO energy.


### PR DESCRIPTION
I cannot pinpoint when exactly this broke, but at least in Python 3.11.2 if you try to run the tests (or examples in sqaodpy/examples) you either get segmentation faults or errors complaining that maximize/minimize cannot be interpreted as integers.

Defining `__index__ = __int__` in the maximize/minimize classes solves this problem.